### PR TITLE
Support treemap plotting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ all = ["run-ruff", "run-vermin", "run-mypy"]
 
 [tool.hatch.envs.test]
 dependencies = [
+  "kaleido",
   "matplotlib",
   "networkx>=3",
   "plotly",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,10 @@ dependencies = [
 
 [project.optional-dependencies]
 draw = [
-    "matplotlib",
-    "networkx",
+  "kaleido",
+  "matplotlib",
+  "networkx",
+  "plotly",
 ]
 
 [project.urls]
@@ -62,6 +64,7 @@ all = ["run-ruff", "run-vermin", "run-mypy"]
 dependencies = [
   "matplotlib",
   "networkx>=3",
+  "plotly",
   "pytest>=8.3",
   "pytest-cov>=6.0",
 ]

--- a/rosetree/__init__.py
+++ b/rosetree/__init__.py
@@ -3,9 +3,10 @@
 from .draw import TreeDrawOptions, TreeLayoutOptions
 from .tree import FrozenTree, MemoTree, Tree, zip_trees, zip_trees_with
 from .trie import Trie
+from .weighted import Treemap
 
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 __all__ = [
     'FrozenTree',
@@ -13,6 +14,7 @@ __all__ = [
     'Tree',
     'TreeDrawOptions',
     'TreeLayoutOptions',
+    'Treemap',
     'Trie',
     'zip_trees',
     'zip_trees_with',

--- a/rosetree/draw.py
+++ b/rosetree/draw.py
@@ -14,7 +14,7 @@ from .utils import cumsums, make_percent
 
 
 if TYPE_CHECKING:
-    import plotly.graph_objects as go
+    import plotly.graph_objects as go  # type: ignore[import-not-found]
 
     from .tree import BaseTree
     from .weighted import NodeWeightInfo, Treemap
@@ -435,7 +435,7 @@ def _draw_plotly_treemap(treemap: Treemap[T], color_func: Optional[Callable[[T],
 def show_or_save_figure(fig: go.Figure, filename: Optional[str] = None, **kwargs: Any) -> None:
     """Given a plotly Figure and an optional filename, displays the figure if the filename is None, and otherwise saves it to the given file.
     Any extra keyword arguments are passed to either Figure.show or write_image."""
-    import plotly.io as pio
+    import plotly.io as pio  # type: ignore[import-not-found]
     if filename is None:
         fig.show(**kwargs)
     else:

--- a/rosetree/draw.py
+++ b/rosetree/draw.py
@@ -20,12 +20,16 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-# CONSTANTS
+#############
+# CONSTANTS #
+#############
 
 _PARTITION_REGEX = re.compile(r'^(\s*)([^\s](.*[^\s])?)(\s*)$')
 
 
-# TYPES
+#########
+# TYPES #
+#########
 
 # color as string or RGB(A) tuple
 Color = Union[str, tuple[float, ...]]
@@ -45,6 +49,10 @@ class Box(NamedTuple):
 
 BoxPair = tuple[Box, Box]
 
+
+#############
+# ASCII ART #
+#############
 
 # LONG FORMAT
 
@@ -216,7 +224,10 @@ def pretty_tree_wide(tree: BaseTree[T], *, top_down: bool = False, spacing: int 
     lines = _pad_lines(lines)
     return '\n'.join(lines)
 
-# PLANAR DRAWING
+
+##################
+# PLANAR DRAWING #
+##################
 
 @dataclass
 class TreeLayoutOptions:
@@ -370,3 +381,8 @@ class TreeDrawOptions:
             plt.show()
         else:  # save plot to file
             plt.savefig(filename)
+
+
+#######################
+# NODE-WEIGHTED TREES #
+#######################

--- a/rosetree/tree.py
+++ b/rosetree/tree.py
@@ -318,6 +318,16 @@ class BaseTree(ABC, Sequence['BaseTree[T]']):
             return paths[pair[0]]
         return self.tag_with_unique_counter().map(get_path)
 
+    def tag_with_index_path(self) -> BaseTree[tuple[tuple[int, ...], T]]:
+        """Converts each tree node to a pair (idx_path, node), where idx_path is a sequence of integers representing the path down the tree."""
+        cls = cast(Type[BaseTree[int]], type(self))
+        def to_child_index_tree(node: T, children: Sequence[BaseTree[int]]) -> BaseTree[int]:
+            # creates a tree where each child node is its index
+            return cls(0, [cls(i, list(child)) for (i, child) in enumerate(children)])
+        idx_tree = self.fold(to_child_index_tree)
+        idx_path_tree = idx_tree.to_path_tree()
+        return cast(BaseTree[tuple[tuple[int, ...], T]], zip_trees(idx_path_tree, self))
+
     # DRAWING
 
     def pretty(self, style: TreeStyle = 'top-down') -> str:

--- a/rosetree/utils.py
+++ b/rosetree/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from itertools import accumulate, chain
+import math
 from typing import Hashable, Mapping, TypeVar
 
 
@@ -18,3 +19,20 @@ def merge_dicts(d1: Mapping[K, V], d2: Mapping[K, V]) -> dict[K, V]:
 def cumsums(xs: Iterable[float]) -> list[float]:
     """Computes cumulative sums of a sequence of numbers, starting with 0."""
     return list(accumulate(chain([0.0], xs)))
+
+def round_significant_figures(x: float, sigfigs: int) -> float:
+    """Rounds a number to some number of significant figures."""
+    if x == 0:
+        return 0
+    abs_x = abs(x)
+    order = math.floor(math.log10(abs_x))
+    factor = 10 ** (sigfigs - 1 - order)
+    return math.copysign(round(abs_x * factor) / factor, x)
+
+def make_percent(x: float) -> str:
+    """Converts a float to a readable percentage."""
+    pct = 100.0 * x
+    pct = round_significant_figures(pct, 2)
+    if pct == int(pct):
+        pct = int(pct)
+    return f'{pct}%'

--- a/rosetree/weighted.py
+++ b/rosetree/weighted.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from math import isfinite
 from operator import add, itemgetter
-from typing import Literal, NamedTuple, Optional, Type, TypeVar, cast
+from typing import Any, Literal, NamedTuple, Optional, Type, TypeVar, cast
 
 from typing_extensions import Self
 
@@ -89,11 +89,11 @@ class Treemap(Tree[tuple[NodeWeightInfo, T]]):
             return (info, pair[1])
         return cls.wrap(zip_trees_with(replace_weight, weight_info_tree, tree), deep=True)  # type: ignore[misc]
 
-    def draw_treemap(self, filename: Optional[str] = None, *, style: TreemapStyle = 'treemap') -> None:
+    def draw_treemap(self, filename: Optional[str] = None, *, style: TreemapStyle = 'treemap', **kwargs: Any) -> None:
         """Draws a treemap diagram.
         If a filename is provided, saves it to this file.
-        A style may also be provided ('treemap', 'icicle', or 'sunburst'), indicating what style of treemap plot to make."""
+        A style may also be provided ('treemap', 'icicle', or 'sunburst'), indicating what style of treemap plot to make.
+        Extra keyword arguments are passed to either Figure.show or write_image."""
         from rosetree.draw import _draw_plotly_treemap, show_or_save_figure
-        # TODO: what info to show; extra plotly options
         fig = _draw_plotly_treemap(self, style=style)
-        show_or_save_figure(fig, filename)
+        show_or_save_figure(fig, filename, **kwargs)

--- a/rosetree/weighted.py
+++ b/rosetree/weighted.py
@@ -85,3 +85,11 @@ class Treemap(Tree[tuple[NodeWeightInfo, T]]):
         def replace_weight(info: NodeWeightInfo, pair: WeightedNode[T]) -> tuple[NodeWeightInfo, T]:
             return (info, pair[1])
         return cls.wrap(zip_trees_with(replace_weight, weight_info_tree, tree), deep=True)  # type: ignore[misc]
+
+    def draw_treemap(self, filename: Optional[str] = None) -> None:
+        """Draws a treemap diagram.
+        If a filename is provided, saves it to this file."""
+        from rosetree.draw import _draw_plotly_treemap, show_or_save_figure
+        # TODO: what info to show; extra plotly options
+        fig = _draw_plotly_treemap(self)
+        show_or_save_figure(fig, filename)

--- a/rosetree/weighted.py
+++ b/rosetree/weighted.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from math import isfinite
 from operator import add, itemgetter
-from typing import NamedTuple, Optional, Type, TypeVar, cast
+from typing import Literal, NamedTuple, Optional, Type, TypeVar, cast
 
 from typing_extensions import Self
 
@@ -19,6 +19,9 @@ Weight = float
 WeightedNode = tuple[Weight, T]
 # a tree with weights on the nodes
 NodeWeightedTree = BaseTree[WeightedNode[T]]
+
+# style for plotting a treemap (node-weighted tree)
+TreemapStyle = Literal['treemap', 'icicle', 'sunburst']
 
 
 def _safe_divide(weight1: Weight, weight2: Weight) -> Optional[float]:
@@ -86,10 +89,11 @@ class Treemap(Tree[tuple[NodeWeightInfo, T]]):
             return (info, pair[1])
         return cls.wrap(zip_trees_with(replace_weight, weight_info_tree, tree), deep=True)  # type: ignore[misc]
 
-    def draw_treemap(self, filename: Optional[str] = None) -> None:
+    def draw_treemap(self, filename: Optional[str] = None, *, style: TreemapStyle = 'treemap') -> None:
         """Draws a treemap diagram.
-        If a filename is provided, saves it to this file."""
+        If a filename is provided, saves it to this file.
+        A style may also be provided ('treemap', 'icicle', or 'sunburst'), indicating what style of treemap plot to make."""
         from rosetree.draw import _draw_plotly_treemap, show_or_save_figure
         # TODO: what info to show; extra plotly options
-        fig = _draw_plotly_treemap(self)
+        fig = _draw_plotly_treemap(self, style=style)
         show_or_save_figure(fig, filename)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -300,9 +300,11 @@ def _is_increasing(it, strict: bool = True):
 def use_agg_backend():
     """Temporarily sets the matplotlib backend to 'Agg', which does not make use of a GUI."""
     backend = matplotlib.get_backend()
+    matplotlib.pyplot.close('all')
     matplotlib.use('Agg', force=True)
     importlib.reload(matplotlib.pyplot)
     yield
+    matplotlib.pyplot.close('all')
     matplotlib.use(backend, force=True)
     importlib.reload(matplotlib.pyplot)
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -256,6 +256,26 @@ def test_tag_with_hash(cls):
     else:
         assert not hasattr(cls, 'tag_with_hash')
 
+def test_to_path_tree():
+    """Tests conversion of nodes to paths."""
+    tree2 = TREE1.to_path_tree()
+    assert tree2 == Tree((0,), [
+        Tree((0, 1)),
+        Tree((0, 2), [
+            Tree((0, 2, 3), [
+                Tree((0, 2, 3, 4), [
+                    Tree((0, 2, 3, 4, 5))
+                ])
+            ]),
+            Tree((0, 2, 6), [
+                Tree((0, 2, 6, 7)),
+                Tree((0, 2, 6, 8))
+            ])
+        ])
+    ])
+    for preorder in [False, True]:
+        assert list(TREE1.iter_paths(preorder=preorder)) == list(tree2.iter_nodes(preorder=preorder))
+
 @pytest.mark.parametrize('cls', TREE_CLASSES)
 def test_dict(cls):
     """Tests conversion to/from a dict."""

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -257,7 +257,7 @@ def test_tag_with_hash(cls):
         assert not hasattr(cls, 'tag_with_hash')
 
 def test_to_path_tree():
-    """Tests conversion of nodes to paths."""
+    """Tests the to_path_tree method."""
     tree2 = TREE1.to_path_tree()
     assert tree2 == Tree((0,), [
         Tree((0, 1)),
@@ -269,13 +269,35 @@ def test_to_path_tree():
             ]),
             Tree((0, 2, 6), [
                 Tree((0, 2, 6, 7)),
-                Tree((0, 2, 6, 8))
+                Tree((0, 2, 6, 8)),
             ])
         ])
     ])
     assert tree2.map(lambda path: path[-1]) == TREE1
     for preorder in [False, True]:
         assert list(TREE1.iter_paths(preorder=preorder)) == list(tree2.iter_nodes(preorder=preorder))
+
+def test_tag_with_index_path():
+    """Tests the tag_with_index_path method."""
+    tree2 = TREE1.tag_with_index_path()
+    assert tree2 == Tree(((0,), 0), [
+        Tree(((0, 0), 1)),
+        Tree(((0, 1), 2), [
+            Tree(((0, 1, 0), 3), [
+                Tree(((0, 1, 0, 0), 4), [
+                    Tree(((0, 1, 0, 0, 0), 5))
+                ])
+            ]),
+            Tree(((0, 1, 1), 6), [
+                Tree(((0, 1, 1, 0), 7)),
+                Tree(((0, 1, 1, 1), 8)),
+            ])
+        ])
+    ])
+    assert tree2.map(itemgetter(1)) == TREE1
+    # index paths in preorder traversal order are sorted
+    idx_paths = [idx_path for (idx_path, _) in tree2.iter_nodes()]
+    assert sorted(idx_paths) == idx_paths
 
 @pytest.mark.parametrize('cls', TREE_CLASSES)
 def test_dict(cls):

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -273,6 +273,7 @@ def test_to_path_tree():
             ])
         ])
     ])
+    assert tree2.map(lambda path: path[-1]) == TREE1
     for preorder in [False, True]:
         assert list(TREE1.iter_paths(preorder=preorder)) == list(tree2.iter_nodes(preorder=preorder))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rosetree.utils import merge_dicts
+from rosetree.utils import make_percent, merge_dicts, round_significant_figures
 
 
 @pytest.mark.parametrize(['d1', 'd2', 'output'], [
@@ -16,3 +16,30 @@ def test_merge_dicts(d1, d2, output):
             _ = merge_dicts(d1, d2)
     else:
         assert merge_dicts(d1, d2) == output
+
+@pytest.mark.parametrize(['x', 'sigfigs', 'output'], [
+    (0, 0, 0),
+    (0, 3, 0),
+    (2.7, 1, 3),
+    (2.7, 2, 2.7),
+    (2.7, 5, 2.7),
+])
+def test_round_significant_figures(x, sigfigs, output):
+    assert round_significant_figures(x, sigfigs) == output
+
+@pytest.mark.parametrize(['x', 'percent'], [
+    (0, '0%'),
+    (0.000001, '0.0001%'),
+    (0.0001, '0.01%'),
+    (0.001, '0.1%'),
+    (0.01, '1%'),
+    (0.1, '10%'),
+    (0.5, '50%'),
+    (0.99, '99%'),
+    (0.994, '99%'),
+    (0.995, '100%'),
+    (0.999, '100%'),
+    (1, '100%'),
+])
+def test_make_percent(x, percent):
+    assert make_percent(x) == percent

--- a/tests/test_weighted.py
+++ b/tests/test_weighted.py
@@ -5,7 +5,7 @@ from operator import add, attrgetter
 import pytest
 
 from rosetree import Tree
-from rosetree.weighted import NodeWeightInfo, aggregate_node_weighted_tree, aggregate_weight_info
+from rosetree.weighted import NodeWeightInfo, Treemap, aggregate_weight_info
 
 
 def flip(pair):
@@ -155,4 +155,4 @@ def test_aggregate_weight_info_valid(tree1, tree2):
     tree3 = tree1.tag_with_unique_counter().map(flip)
     tree4 = tree1_agg.tag_with_unique_counter().map(flip)
     # aggregation of tree with counter tags matches counter-tagged aggregate tree
-    assert aggregate_node_weighted_tree(tree3) == tree4
+    assert Treemap.from_node_weighted_tree(tree3) == Treemap.wrap(tree4, deep=True)

--- a/tests/test_weighted.py
+++ b/tests/test_weighted.py
@@ -7,7 +7,7 @@ import pytest
 
 from rosetree import Tree, Trie
 from rosetree.draw import _plotly_treemap_args
-from rosetree.weighted import NodeWeightInfo, Treemap, aggregate_weight_info
+from rosetree.weighted import NodeWeightInfo, Treemap, TreemapStyle, aggregate_weight_info
 
 
 def flip(pair):
@@ -199,14 +199,17 @@ def test_budget_treemap(monkeypatch, tmp_path, budget_tree):
     monkeypatch.setattr(go.Figure, 'show', lambda _: None)
     treemap = Treemap.from_node_weighted_tree(budget_tree)
     args = _plotly_treemap_args(treemap)
-    assert args['branchvalues'] == 'remainder'
-    assert args['values'] == [info.weight for (info, _) in treemap.iter_nodes()]
+    assert args['branchvalues'] == 'total'
+    assert args['values'] == [info.subtotal for (info, _) in treemap.iter_nodes()]
     assert args['marker_colors'] is None
     color_func = lambda _: 'green'
     args = _plotly_treemap_args(treemap, color_func=color_func)
     assert args['marker_colors'] == ['green' for _ in range(treemap.size)]
     # create plotly plot (but don't actually display it)
-    treemap.draw_treemap()
+    for style in TreemapStyle.__args__:
+        treemap.draw_treemap(style=style)
+    with pytest.raises(ValueError, match="invalid treemap style 'fake'"):
+        treemap.draw_treemap(style='fake')
     # save plot to an SVG file
     try:
         svg_path = tmp_path / 'treemap.svg'

--- a/tests/test_weighted.py
+++ b/tests/test_weighted.py
@@ -208,6 +208,9 @@ def test_budget_treemap(monkeypatch, tmp_path, budget_tree):
     # create plotly plot (but don't actually display it)
     treemap.draw_treemap()
     # save plot to an SVG file
-    svg_path = tmp_path / 'treemap.svg'
-    treemap.draw_treemap(svg_path)
-    assert svg_path.exists()
+    try:
+        svg_path = tmp_path / 'treemap.svg'
+        treemap.draw_treemap(svg_path)
+        assert svg_path.exists()
+    except ValueError as e:
+        pytest.skip(f'Could not save treemap: {e}')


### PR DESCRIPTION
Closes #5.

- Add `Treemap` class for storing contextual info about node weights.
- Plot treemaps via `plotly` library (treemap, icicle, or sunburst), which is included among `draw` optional dependencies.  Can save plots to files via `kaleido` backend.
- For now we do not expose options to customize the info text appearing in a treemap block.  We can do so if the need arises in the future.